### PR TITLE
switch pubmed predicate to skos:exactMatch

### DIFF
--- a/docs.php
+++ b/docs.php
@@ -37,7 +37,7 @@ while ($row = mysql_fetch_assoc($allIDs)) {
   }
   if ($row['pubmed_id']) {
     echo data_triple( $resource, $BIBO . "pmid", $row['pubmed_id'] );
-    echo triple( $resource, $RDFS . "seeAlso", "http://bio2rdf.org/pubmed:" . $row['pubmed_id'] );
+    echo triple( $resource, $SKOS . "exactMatch", "http://bio2rdf.org/pubmed:" . $row['pubmed_id'] );
   }
   echo data_triple( $resource, $DC . "date", $row['year'] );
   echo data_triple( $resource, $BIBO . "volume", $row['volume'] );

--- a/namespaces.php
+++ b/namespaces.php
@@ -9,6 +9,7 @@ $DC = "http://purl.org/dc/elements/1.1/";
 $BIBO = "http://purl.org/ontology/bibo/";
 $FOAF = "http://xmlns.com/foaf/0.1/";
 $CITO = "http://purl.org/spar/cito/";
+$SKOS = "http://www.w3.org/2004/02/skos/core#";
 
 $OBO  =  "http://purl.obolibrary.org/obo#";
 $BODO = "http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#";


### PR DESCRIPTION
rdfs:seeAlso switched to skos:exactMatch to indicate that both URIs are about articles and they could be used interchangeably in most circumstances, per the SKOS definition http://www.w3.org/TR/skos-reference/#mapping
